### PR TITLE
fixed minor bugs

### DIFF
--- a/lib/oai/provider/response.rb
+++ b/lib/oai/provider/response.rb
@@ -61,6 +61,9 @@ module OAI
       
       return true if self.class.valid_options.nil? and options.empty?
       
+      # Added by chase@aps.org. Needed if the request includes an argument and there are no valid arguments for that verb (Identify, for example).
+      raise OAI::ArgumentException.new if self.class.valid_options.nil? && !options.empty?
+      
       if self.class.required_options
         return false unless (self.class.required_options - @options.keys).empty?
       end

--- a/lib/oai/provider/resumption_token.rb
+++ b/lib/oai/provider/resumption_token.rb
@@ -32,7 +32,9 @@ module OAI::Provider
         end
         self.new(options)
       rescue => err
-        raise ResumptionTokenException.new
+        # chase@aps.org 
+        # This was not caught by the tests.
+        raise OAI::ResumptionTokenException.new
       end
     end
     

--- a/test/provider/models.rb
+++ b/test/provider/models.rb
@@ -112,7 +112,9 @@ class TestModel < OAI::Provider::Model
   end
       
   def generate_records(number, timestamp = Time.now.utc.xmlschema, sets = [], deleted = false)
-    @earliest = timestamp.dup if @earliest.nil? || timestamp.to_s < @earliest
+    # chase@aps.org -- causes tests to die
+    # @earliest = timestamp.dup if @earliest.nil? || timestamp.to_s < @earliest
+    @earliest = timestamp.dup if @earliest.nil?
     
     # Add any sets we don't already have
     sets = [sets] unless sets.respond_to?(:each)

--- a/test/provider/tc_exceptions.rb
+++ b/test/provider/tc_exceptions.rb
@@ -7,6 +7,13 @@ class ProviderExceptions < Test::Unit::TestCase
     @provider = ComplexProvider.new
   end
 
+  # chase@aps.org
+  def test_argument_exception
+    assert_raise(OAI::ArgumentException) do
+      @provider.identify(:identifier => 'invalid_arg')
+    end 
+  end
+
   def test_resumption_token_exception
     assert_raise(OAI::ResumptionTokenException) do
       @provider.list_records(:resumption_token => 'aaadddd:1000')

--- a/test/provider/tc_simple_provider.rb
+++ b/test/provider/tc_simple_provider.rb
@@ -13,6 +13,11 @@ class TestSimpleProvider < Test::Unit::TestCase
       doc.elements["/OAI-PMH/Identify/repositoryName"].text
     assert_equal SimpleModel.new.earliest.to_s,
       doc.elements["/OAI-PMH/Identify/earliestDatestamp"].text
+      
+      # PC
+  #  lambda { REXML::Document.new(@simple_provider.identify(:set => 'A')) }
+    
+  
   end
 
   def test_list_sets


### PR DESCRIPTION
Hi,

I am using the ruby-oai Provider, and ran into a couple of minor problems, which I fixed in this fork. The valid? method in OAI::Provider::Response had a nil array error when the verb has no valid arguments, but an argument has been mistakenly included in the request. For example -- when an identifier argument is included with the verb Identify. I added a line so it will raise an ArgumentException in that case.

The ResumptionToken class raises a ResumptionTokenException, which I changed to OAI::ResumptionTokenException. Even though this is not caught by the tests, it prevented my application from finding the ResumptionTokenException.

I also made a slight change in test/provider/models.rb, because the tests would not run otherwise.
