### PR TITLE
Changes to ActiveRecordWrapper

### DIFF
--- a/lib/oai/provider/model/activerecord_wrapper.rb
+++ b/lib/oai/provider/model/activerecord_wrapper.rb
@@ -24,7 +24,7 @@ module OAI::Provider
         )
       end
     end
-    
+
     def earliest
       model.find(:first, 
         :order => "#{timestamp_field} asc").send(timestamp_field)
@@ -65,6 +65,22 @@ module OAI::Provider
       false
     end    
     
+    def respond_to?(m, include_private=false)
+      if m =~ /^map_/ and @model.respond_to?(m)
+        true
+      else
+        super
+      end
+    end
+
+    def method_missing(m, *args, &block)
+      if m =~ /^map_/ and @model.respond_to?(m)
+        @model.send(m, *args, &block)
+      else
+        super
+      end
+    end
+
     protected
     
     # Request the next set in this sequence.
@@ -120,7 +136,7 @@ module OAI::Provider
       sql << "#{timestamp_field} >= ?" << "#{timestamp_field} <= ?" 
       sql << "set = ?" if opts[:set]
       esc_values = [sql.join(" AND ")]
-      esc_values << Time.parse(opts[:from]).localtime << Time.parse(opts[:until]).localtime #-- OAI 2.0 hack - UTC fix from record_responce 
+      esc_values << Time.parse(opts[:from].to_s).localtime << Time.parse(opts[:until].to_s).localtime.to_s #-- OAI 2.0 hack - UTC fix from record_responce 
       esc_values << opts[:set] if opts[:set]
       
       return esc_values


### PR DESCRIPTION
In trying to use ActiveRecordWrapper in a Rails Engine, I came across 2 issues.

1st, was "TypeError (can't convert Time into String)", caused by the argument to Time.parse being a Time object itself.

2nd was that even if I implement map_{prefix} in my model, if I used ActiveRecordWrapper to wrap my model, then when OAI::Provider::Metadata::Format.encode asked if model.respond_to("map_#{prefix}") it would be false. This is because "model" is an ActiveRecordWrapper and not the class of the wrapped model.

I've fixed both issues in this commit.
