### PR TITLE
minor tweaks

### DIFF
--- a/lib/oai/client.rb
+++ b/lib/oai/client.rb
@@ -206,8 +206,7 @@ module OAI
       case @parser
       when 'libxml'
         begin
-          parser = XML::Parser.new()
-          parser.string = xml
+          parser = XML::Parser.string()
           return parser.parse
         rescue XML::Parser::ParseError => e
           raise OAI::Exception, 'response not well formed XML: '+e, caller

--- a/lib/oai/harvester.rb
+++ b/lib/oai/harvester.rb
@@ -1,3 +1,4 @@
+require 'time'
 require 'zlib'
 require 'net/smtp'
 require 'yaml'

--- a/lib/oai/harvester/harvest.rb
+++ b/lib/oai/harvester/harvest.rb
@@ -72,7 +72,7 @@ module OAI
         
         file = Tempfile.new('oai_data')
         gz = Zlib::GzipWriter.new(file)
-        gz << "<? xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
+        gz << "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
         gz << "<records>"
         begin
           response = client.list_records(options)


### PR DESCRIPTION
a few tweaks for the cli harvester.

the modification in client.rb is due to this warning:
.rbenv/versions/1.8.7-p352/lib/ruby/gems/1.8/gems/oai-0.0.13/lib/oai/client.rb:193: warning: Passing no parameters to XML::Parser.new is deprecated.  Pass an instance of XML::Parser::Context instead.
