### PR TITLE
Removing require for "iconv"

### DIFF
--- a/lib/oai/client.rb
+++ b/lib/oai/client.rb
@@ -2,7 +2,6 @@
 require 'uri'
 require 'faraday'
 require 'cgi'
-require 'iconv'
 
 if not defined?(OAI::Const::VERBS)
   # Shared stuff


### PR DESCRIPTION
It triggers warnings in Ruby 1.9.x, and it appears to be completely unused.
