### PR TITLE
Fixing handling for databases using UTC dates.

### DIFF
--- a/lib/oai/provider/model/activerecord_wrapper.rb
+++ b/lib/oai/provider/model/activerecord_wrapper.rb
@@ -156,7 +156,9 @@ module OAI::Provider
     def parse_to_local(time)
       time_obj = Time.parse(time.to_s)
       time_obj = yield(time_obj) if block_given?
-      time_obj.localtime.strftime("%Y-%m-%d %H:%M:%S")
+      # Convert to same as DB - :local => :getlocal, :utc => :getutc
+      tzconv = "get#{model.default_timezone.to_s}".to_sym
+      time_obj.send(tzconv).strftime("%Y-%m-%d %H:%M:%S")
     end
 
   end

--- a/test/activerecord_provider/tc_ar_provider.rb
+++ b/test/activerecord_provider/tc_ar_provider.rb
@@ -114,3 +114,19 @@ class ActiveRecordProviderTest < TransactionalTestCase
   end
 
 end
+
+class ActiveRecordProviderTimezoneTest < ActiveRecordProviderTest
+
+  def setup
+    require 'active_record'
+    ActiveRecord::Base.default_timezone = :utc
+    super
+  end
+
+  def teardown
+    require 'active_record'
+    ActiveRecord::Base.default_timezone = :local
+    super
+  end
+
+end


### PR DESCRIPTION
Not all activerecord setups store dates in the database using the local time zone, so UTC also needs to be handled.

This fix reruns the provider tests using UTC dates for good measure.
