### PR TITLE
Fixing testing dependencies for JRuby

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
-pkg
-doc
+/pkg/
+/doc/
+/coverage*
+
+# Exclude Gemfile.lock (best practice for gems)
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ language: ruby
 rvm:
   - 1.8.7
   - 1.9.3
+  - jruby-18mode
+  - jruby-19mode
 script: bundle exec rake test

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,16 @@ source "http://rubygems.org"
 
 gemspec
 
-
 gem 'jruby-openssl', :platform => :jruby
-gem 'rcov', '~> 0.9', :platform => [:mri_18, :jruby]
-gem 'simplecov', :platform => :mri_19
-gem 'simplecov-rcov', :platform => :mri_19
+
+group :test do
+  gem 'activerecord'
+  gem 'activerecord-jdbcsqlite3-adapter', :platform => [:jruby]
+  gem 'libxml-ruby', :platform => [:ruby, :mswin]
+  gem 'rake'
+  gem 'rdoc'
+  gem 'rcov', '~> 0.9', :platform => [:ruby_18, :jruby]
+  gem 'simplecov', :platform => :ruby_19
+  gem 'simplecov-rcov', :platform => :ruby_19
+  gem 'sqlite3', :platform => [:ruby, :mswin]
+end

--- a/ruby-oai.gemspec
+++ b/ruby-oai.gemspec
@@ -14,11 +14,6 @@ Gem::Specification.new do |s|
     s.add_dependency('builder', '>=2.0.0')
     s.add_dependency('faraday')
     s.add_dependency('faraday_middleware')
-    s.add_development_dependency('rake')
-    s.add_development_dependency('activerecord')
-    s.add_development_dependency('sqlite3')
-    s.add_development_dependency('rdoc')
-    s.add_development_dependency('libxml-ruby')
 
     s.files = %w(README.md Rakefile) +
       Dir.glob("{bin,test,lib}/**/*") +


### PR DESCRIPTION
The existing tests ran for JRuby, but the test dependencies didn't take into account `libxml-ruby` being a native library, or the additional JDBC dependency for `sqlite3`.
