### PR TITLE
Simpler provider set handling through reflection

### DIFF
--- a/test/activerecord_provider/database/0001_oaipmh_tables.rb
+++ b/test/activerecord_provider/database/0001_oaipmh_tables.rb
@@ -10,7 +10,7 @@ class OaipmhTables < ActiveRecord::Migration
       t.column :oai_token_id, :integer, :null => false
     end
 
-    create_table :dc_fields do |t|
+    dc_fields = proc do |t|
       t.column  :title,         :string
       t.column  :creator,       :string
       t.column  :subject,       :string
@@ -29,6 +29,13 @@ class OaipmhTables < ActiveRecord::Migration
       t.column  :created_at,    :datetime
       t.column  :deleted,       :boolean,   :default => false
     end
+
+    create_table :exclusive_set_dc_fields do |t|
+      dc_fields.call(t)
+      t.column  :set,           :string
+    end
+
+    create_table :dc_fields, &dc_fields
 
     create_table :dc_fields_dc_sets, :id => false do |t|
       t.column :dc_field_id,    :integer

--- a/test/activerecord_provider/helpers/set_provider.rb
+++ b/test/activerecord_provider/helpers/set_provider.rb
@@ -1,31 +1,11 @@
 # Extend ActiveRecordModel to support sets
 class SetModel < OAI::Provider::ActiveRecordWrapper
-  
+
   # Return all available sets
   def sets
-    DCSet.find(:all)
+    DCSet.scoped
   end
 
-  # Scope the find to a set relation if we get a set in the options    
-  def find(selector, opts={})
-    if opts[:set]
-      set = DCSet.find_by_spec(opts.delete(:set))
-      conditions = sql_conditions(opts)
-
-      if :all == selector
-        set.dc_fields.find(selector, :conditions => conditions)
-      else
-        set.dc_fields.find(selector, :conditions => conditions)
-      end
-    else
-      if :all == selector
-        model.find(selector, :conditions => sql_conditions(opts))
-      else
-        model.find(selector, :conditions => sql_conditions(opts))
-      end
-    end
-  end
-        
 end
 
 class ARSetProvider < OAI::Provider::Base
@@ -33,4 +13,12 @@ class ARSetProvider < OAI::Provider::Base
   repository_url 'http://localhost'
   record_prefix = 'oai:test'
   source_model SetModel.new(DCField, :timestamp_field => 'date')
+end
+
+class ARExclusiveSetProvider < OAI::Provider::Base
+  repository_name 'ActiveRecord Set Based Provider'
+  repository_url 'http://localhost'
+  record_prefix = 'oai:test'
+  source_model OAI::Provider::ActiveRecordWrapper.new(
+    ExclusiveSetDCField, :timestamp_field => 'date')
 end

--- a/test/activerecord_provider/helpers/transactional_test_case.rb
+++ b/test/activerecord_provider/helpers/transactional_test_case.rb
@@ -11,7 +11,7 @@ class TransactionalTestCase < Test::Unit::TestCase
     result
   end
 
-  private
+  protected
 
   def load_fixtures
     fixtures = YAML.load_file(

--- a/test/activerecord_provider/models/dc_set.rb
+++ b/test/activerecord_provider/models/dc_set.rb
@@ -1,6 +1,7 @@
 class DCSet < ActiveRecord::Base
-  has_and_belongs_to_many :dc_fields, 
-    :join_table => "dc_fields_dc_sets", 
+  has_and_belongs_to_many :dc_fields,
+    :join_table => "dc_fields_dc_sets",
     :foreign_key => "dc_set_id",
     :class_name => "DCField"
+
 end

--- a/test/activerecord_provider/models/exclusive_set_dc_field.rb
+++ b/test/activerecord_provider/models/exclusive_set_dc_field.rb
@@ -1,0 +1,11 @@
+class ExclusiveSetDCField < ActiveRecord::Base
+  inheritance_column = 'DONOTINHERIT'
+
+  def self.sets
+    klass = Struct.new(:name, :spec)
+    self.uniq.pluck('`set`').compact.map do |spec|
+      klass.new("Set #{spec}", spec)
+    end
+  end
+
+end


### PR DESCRIPTION
Sets can be now be configured by having a `:set` attribute, or by having proper set models that relate back to the provider model.

Overriding `Provider.find` should no longer be necessary, which avoids the possibility of messing up resumption token behaviour.
