### PR TITLE
Pegging version for activerecord to fix Travis CI tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 gem 'jruby-openssl', :platform => :jruby
 
 group :test do
-  gem 'activerecord'
+  gem 'activerecord', '~> 3.2.8'
   gem 'activerecord-jdbcsqlite3-adapter', :platform => [:jruby]
   gem 'libxml-ruby', :platform => [:ruby, :mswin]
   gem 'rake'


### PR DESCRIPTION
Without pegging the version, an initial `bundle install` was picking up ActiveRecord 2.0 (because `Gemfile.lock` is intentionally excluded from the gem).

ActiveRecord is now pegged to `~> 3.2.8`.
