### PR TITLE
Remove bad whitespace from XML

### DIFF
--- a/lib/oai/provider.rb
+++ b/lib/oai/provider.rb
@@ -155,8 +155,7 @@ end
 #        'xmlns:dc' => "http://purl.org/dc/elements/1.1/",
 #        'xmlns:xsi' => "http://www.w3.org/2001/XMLSchema-instance",
 #        'xsi:schemaLocation' => 
-#          %{http://www.openarchives.org/OAI/2.0/oai_dc/ 
-#            http://www.openarchives.org/OAI/2.0/oai_dc.xsd}) do
+#          %{http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd}) do
 #          xml.tag!('oai_dc:title', title)
 #          xml.tag!('oai_dc:description', text)
 #          xml.tag!('oai_dc:creator', user)

--- a/lib/oai/provider/metadata_format/oai_dc.rb
+++ b/lib/oai/provider/metadata_format/oai_dc.rb
@@ -19,9 +19,7 @@ module OAI::Provider::Metadata
         'xmlns:oai_dc' => "http://www.openarchives.org/OAI/2.0/oai_dc/",
         'xmlns:dc' => "http://purl.org/dc/elements/1.1/",
         'xmlns:xsi' => "http://www.w3.org/2001/XMLSchema-instance",
-        'xsi:schemaLocation' => 
-          %{http://www.openarchives.org/OAI/2.0/oai_dc/ 
-            http://www.openarchives.org/OAI/2.0/oai_dc.xsd}            
+        'xsi:schemaLocation' => %{http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd}
       }
     end
 

--- a/lib/oai/provider/response.rb
+++ b/lib/oai/provider/response.rb
@@ -48,8 +48,7 @@ module OAI
       { 
         'xmlns' => "http://www.openarchives.org/OAI/2.0/",
         'xmlns:xsi' => "http://www.w3.org/2001/XMLSchema-instance",
-        'xsi:schemaLocation' => %{http://www.openarchives.org/OAI/2.0/
-          http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd}
+        'xsi:schemaLocation' => %{http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd}
       }
     end
     def extract_identifier(id)


### PR DESCRIPTION
The new lines in the code were causing the actual XML to look like
xsi:schemaLocation="http://moowww.openarchives.org/OAI/2.0/&#10;       http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd"

Notice the &#10;

This was causing us some validation errors.
