### PR TITLE
Have client retry GET if it receives a 503

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,4 +16,5 @@ group :test do
   gem 'simplecov', :platform => :ruby_19
   gem 'simplecov-rcov', :platform => :ruby_19
   gem 'sqlite3', :platform => [:ruby, :mswin]
+  gem "mocha", :require => false
 end

--- a/test/client/test_helper.rb
+++ b/test/client/test_helper.rb
@@ -8,6 +8,7 @@ end
 
 require 'oai'
 require 'test/unit'
+require "mocha/setup"
 
 require File.dirname(__FILE__) + '/helpers/provider'
 require File.dirname(__FILE__) + '/helpers/test_wrapper'


### PR DESCRIPTION
If client.get receives a 503, it will retry 3 times before giving up, and throw an exception that indicates what happened. If a failure status code other than 503 is received, it just throws the exception indicating that. The previous behavior if a 503 or other error code was received was to return and empty result without any error message.
