### PR TITLE
Fix to make this compile/valid in Ruby 2.0

### DIFF
--- a/lib/oai/client.rb
+++ b/lib/oai/client.rb
@@ -1,3 +1,5 @@
+# encoding: us-ascii
+
 # External dependencies
 require 'uri'
 require 'faraday'


### PR DESCRIPTION
Enforce "us-ascii" encoding in the lib/oai/client file so the invalid utf-8 characters don't cause a syntax error.

Fixes #30
