### PR TITLE
Discrepancy between sample identifier format and real identifier

### DIFF
--- a/lib/oai/provider/response/record_response.rb
+++ b/lib/oai/provider/response/record_response.rb
@@ -49,7 +49,7 @@ module OAI::Provider::Response
     private
 
     def identifier_for(record)
-      "#{provider.prefix}/#{record.id}"
+      "#{provider.prefix}:#{record.id}"
     end
 
     def timestamp_for(record)


### PR DESCRIPTION
Within OAI::Provider::Response::Identify, the sample identifier is set as 
`r.sampleIdentifier "#{provider.prefix}:#{provider.identifier}"`
which conflicts with the syntax used here 
`"#{provider.prefix}/#{record.id}".`
That should be modified to 
`"#{provider.prefix}:#{record.id}"`
