### PR TITLE
Allow OAI::Client to pass through additional request headers (e.g. From, User-Agent)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 1.8.7
   - 1.9.3
+  - 2.2.1
   - jruby-18mode
   - jruby-19mode
 script: bundle exec rake test

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :test do
   gem 'redcarpet', :platform => :ruby # For fast, Github-like Markdown
   gem 'kramdown', :platform => :jruby # For Markdown without a C compiler
   gem 'rcov', '~> 0.9', :platform => [:ruby_18, :jruby]
+  gem 'test-unit'
   gem 'simplecov', :platform => :ruby_19
   gem 'simplecov-rcov', :platform => :ruby_19
   gem 'sqlite3', :platform => [:ruby, :mswin]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For example to initiate a ListRecords request to pubmed you can:
 
 ```ruby
   require 'oai'
-  client = OAI::Client.new 'http://www.pubmedcentral.gov/oai/oai.cgi'
+  client = OAI::Client.new 'http://www.pubmedcentral.gov/oai/oai.cgi', :headers => { "From" => "oai@example.com" }
   response = client.list_records
   # Get the first page of records
   response.each do |record| 

--- a/lib/oai/client.rb
+++ b/lib/oai/client.rb
@@ -87,6 +87,7 @@ module OAI
       @base = URI.parse base_url
       @debug = options.fetch(:debug, false)
       @parser = options.fetch(:parser, 'rexml')
+      @headers = options.fetch(:headers, {})
 
       @http_client = options.fetch(:http) do
         Faraday.new(:url => @base.clone) do |builder|
@@ -258,7 +259,11 @@ module OAI
 
     # Do the actual HTTP get, following any temporary redirects
     def get(uri)
-      response = @http_client.get uri
+      response = @http_client.get do |req|
+        req.url uri
+        req.headers.merge! @headers
+      end
+
       response.body
     end
 


### PR DESCRIPTION
Fixes #42