### PR TITLE
OAI Provider helper methods should be able to provide value and attributes

### DIFF
--- a/lib/oai/client.rb
+++ b/lib/oai/client.rb
@@ -202,12 +202,13 @@ module OAI
     def do_request(verb, opts = nil)
       # fire off the request and return appropriate DOM object
       uri = build_uri(verb, opts)
+      debug(uri)
       xml = strip_invalid_utf_8_chars(get(uri))
       if @parser == 'libxml'
         # remove default namespace for oai-pmh since libxml
         # isn't able to use our xpaths to get at them
         # if you know a way around thins please let me know
-        xml = xml.gsub(
+        xml.gsub!(
           /xmlns=\"http:\/\/www.openarchives.org\/OAI\/.\..\/\"/, '')
       end
       return load_document(xml)
@@ -263,7 +264,8 @@ module OAI
         req.url uri
         req.headers.merge! @headers
       end
-
+      # Keep cookie session. Needed for old & buggy OAI-PMH provider
+      @headers['Cookie'] ||= response['set-cookie']
       response.body
     end
 

--- a/lib/oai/client/response.rb
+++ b/lib/oai/client/response.rb
@@ -18,11 +18,13 @@ module OAI
   # ```
   class Response
     include OAI::XPath
-    attr_reader :doc, :resumption_token, :resumption_block
+    attr_reader :doc, :resumption_token, :resumption_block, :complete_list_size
 
     def initialize(doc, &resumption_block)
       @doc = doc
-      @resumption_token = xpath(doc, './/resumptionToken')
+      rt_node = xpath_first(doc, './/resumptionToken')
+      @resumption_token = get_text(rt_node)
+      @complete_list_size = get_attribute(rt_node, 'completeListSize')
       @resumption_block = resumption_block
 
       # throw an exception if there was an error

--- a/lib/oai/harvester/logging.rb
+++ b/lib/oai/harvester/logging.rb
@@ -24,8 +24,7 @@ module OAI
           @logger.info { "Starting regular harvest" }
           orig_start(sites)
           begin
-            OAI::Harvester::
-              Mailer.send(@config.mail_server, @config.email, @summary)
+            OAI::Harvester::Mailer.send(@config.mail_server, @config.email, @summary)
           rescue
             @logger.error { "Error sending out summary email: #{$!}"}
           end

--- a/lib/oai/provider/metadata_format.rb
+++ b/lib/oai/provider/metadata_format.rb
@@ -34,7 +34,7 @@ module OAI::Provider::Metadata
               values = value_for(field, record, map)
               if values.respond_to?(:each)
                 values.each do |value|
-                  xml.tag! "#{element_namespace}:#{field}", value
+                  xml.tag! "#{element_namespace}:#{field}", *value
                 end
               else
                 xml.tag! "#{element_namespace}:#{field}", values

--- a/lib/oai/xpath.rb
+++ b/lib/oai/xpath.rb
@@ -22,12 +22,16 @@ module OAI
     # get text for first matching node
     def xpath(doc, path)
       el = xpath_first(doc, path)
-      return unless el
-      case parser_type(doc)
+      get_text el
+    end
+
+    def get_text(node)
+      return unless node
+      case parser_type(node)
       when 'libxml'
-        return el.content
+        return node.content
       when 'rexml'
-        return el.text 
+        return node.text 
       end
       return nil
     end


### PR DESCRIPTION
For instance:
  def relation
    [ 'value without atribute', [ 'french value', { 'xml:lang' => 'fre' } ] ]
  end
with this patch gives
dc:relationvalue without atribute/dc:relation
<dc:relation xml:lang="fre">french value/dc:relation
