### PR TITLE
model.scoped deprecated and removed in activerecord 4+

### DIFF
--- a/lib/oai/provider/model/activerecord_wrapper.rb
+++ b/lib/oai/provider/model/activerecord_wrapper.rb
@@ -105,6 +105,8 @@ module OAI::Provider
         model.where(set: options[:set])
       else
         # Default to empty set, as we've tried everything else
+        # model.scoped deprecated and removed in activerecord 4+
+        return model.all if ActiveRecord::VERSION::MAJOR >= 4
         model.scoped(:limit => 0)
       end
     end


### PR DESCRIPTION
Since ActiveRecord 4.2 (Rails4) has gone and removed the scoped class method, I added a conditional return value using the recommended replacement for model.scoped, which is model.all. I made this conditional on version 4 (major # only) since I didn't want to break any legacy code that still depends on older versions.
