### PR TITLE
ActiveRecord no longer has a "scoped" method

### DIFF
--- a/lib/oai/provider/model/activerecord_wrapper.rb
+++ b/lib/oai/provider/model/activerecord_wrapper.rb
@@ -105,7 +105,7 @@ module OAI::Provider
         model.where(set: options[:set])
       else
         # Default to empty set, as we've tried everything else
-        model.scoped(:limit => 0)
+        model.none
       end
     end
 


### PR DESCRIPTION
Using the newer "none" method is a great way to do what the comment said was being done, return an AR Relation that's a null set.

I'm not totally sure why this code is doing that or what's going on in the ActiveRecord::Wrapper class around 'sets' in general.

I was unable to figure out how to make a test case that exersizes this code.

Closes #49