### PR TITLE
Doc ability to use scope/AR::Relation with ActiveRecordWrapper

### DIFF
--- a/lib/oai/provider.rb
+++ b/lib/oai/provider.rb
@@ -213,6 +213,21 @@ end
 #    end
 #  end
 # ```
+# ### Scopes for restrictions or eager-loading
+#
+# Instead of passing in a Model class to OAI::Provider::ActiveRecordWrapper, you can actually
+# pass in any scope (or ActiveRecord::Relation). This means you can use it for restrictions:
+#
+#     OAI::Provider::ActiveRecordWrapper.new(Post.where(published: true))
+#
+# Or eager-loading an association you will need to create serialization, to avoid n+1 query
+# performance problems:
+#
+#     OAI::Provider::ActiveRecordWrapper.new(Post.includes(:categories))
+#
+# Or both of those in combination, or anything else that returns an ActiveRecord::Relation,
+# including using custom scopes, etc.
+#
 # ### Sets?
 #
 # There is some code written to support oai-pmh "sets" in the ActiveRecord::Wrapper, but

--- a/test/activerecord_provider/helpers/providers.rb
+++ b/test/activerecord_provider/helpers/providers.rb
@@ -12,6 +12,15 @@ class ARProvider < OAI::Provider::Base
   source_model ActiveRecordWrapper.new(DCField)
 end
 
+class ARProviderWithScope < OAI::Provider::Base
+  DATE_LESS_THAN_RESTRICTION = Time.parse("2007-03-12 19:30:22 UTC")
+
+  repository_name 'ActiveRecord Based Provider'
+  repository_url 'http://localhost'
+  record_prefix 'oai:test'
+  source_model ActiveRecordWrapper.new(DCField.where("date < ?", DATE_LESS_THAN_RESTRICTION).includes(:sets))
+end
+
 class SimpleResumptionProvider < OAI::Provider::Base
   repository_name 'ActiveRecord Resumption Provider'
   repository_url 'http://localhost'

--- a/test/activerecord_provider/tc_ar_provider.rb
+++ b/test/activerecord_provider/tc_ar_provider.rb
@@ -28,6 +28,18 @@ class ActiveRecordProviderTest < TransactionalTestCase
     assert_equal 100, doc.elements['OAI-PMH/ListRecords'].to_a.size
   end
 
+  def test_list_records_scope
+    @provider = ARProviderWithScope.new
+
+    doc = nil
+    assert_nothing_raised do
+      doc = REXML::Document.new(@provider.list_records(:metadata_prefix => 'oai_dc'))
+    end
+
+    expected_count = DCField.where("date < ?", ARProviderWithScope::DATE_LESS_THAN_RESTRICTION).count
+    assert_equal expected_count, doc.elements['OAI-PMH/ListRecords'].to_a.size
+  end
+
   def test_list_identifiers
     assert_nothing_raised { REXML::Document.new(@provider.list_identifiers) }
     doc = REXML::Document.new(@provider.list_identifiers)


### PR DESCRIPTION
This was already possible without any code changes, due to the awesomeness of ActiveRecord. (contrary to popular belief, AR can be pretty awesome). And it's quite useful.

This adds a simple test confirming it, and docs pointing it out.