### PR TITLE
non-integer identifiers work in ResumptionToken 

### DIFF
--- a/lib/oai/provider/model/activerecord_wrapper.rb
+++ b/lib/oai/provider/model/activerecord_wrapper.rb
@@ -159,13 +159,13 @@ module OAI::Provider
     # the last 'id' of the previous set is used as the
     # filter to the next set.
     def token_conditions(token)
-      last = token.last
+      last_id = token.last_str
       sql = sql_conditions token.to_conditions_hash
 
-      return sql if 0 == last
+      return sql if "0" == last_id
       # Now add last id constraint
       sql.first << " AND #{identifier_field} > :id"
-      sql.last[:id] = last
+      sql.last[:id] = last_id
 
       return sql
     end

--- a/lib/oai/provider/resumption_token.rb
+++ b/lib/oai/provider/resumption_token.rb
@@ -69,8 +69,7 @@ module OAI::Provider
     def initialize(options, expiration = nil, total = nil)
       @prefix = options[:metadata_prefix]
       @set = options[:set]
-      @last = options[:last].to_i
-      @last_str = options[:last].to_s
+      self.last = options[:last]
       @from = options[:from] if options[:from]
       @until = options[:until] if options[:until]
       @expiration = expiration if expiration
@@ -79,8 +78,7 @@ module OAI::Provider
 
     # convenience method for setting the offset of the next set of results
     def next(last)
-      @last_str = last.to_s
-      @last = last.to_i
+      self.last = last
       self
     end
 
@@ -116,6 +114,13 @@ module OAI::Provider
     end
 
     private
+
+    # take care of our logic to store an integer and a str version, for backwards
+    # compat where it was assumed to be an integer, as well as supporting string.
+    def last=(value)
+      @last = value.to_i
+      @last_str = value.to_s
+    end
 
     def encode_conditions
       encoded_token = @prefix.to_s.dup

--- a/lib/oai/provider/resumption_token.rb
+++ b/lib/oai/provider/resumption_token.rb
@@ -8,16 +8,41 @@ module OAI::Provider
   # The ResumptionToken class forms the basis of paging query results.  It
   # provides several helper methods for dealing with resumption tokens.
   #
+  # OAI-PMH spec does not specify anything about resumptionToken format, they can
+  # be purely opaque tokens.
+  #
+  # Our implementation however encodes everything needed to construct the next page
+  # inside the resumption token.
+  #
+  # == The 'last' component: offset or ID/pk to resume from
+  #
+  # The `#last` component is an offset or ID to resume from. In the case of it being
+  # an ID to resume from, this assumes that ID's are sortable and results are returned
+  # in ID order, so that the 'last' ID can be used as the place to resume from.
+  #
+  # Originally it was assumed that #last was always an integer, but since existing
+  # implementations (like ActiveRecordWrapper) used it as an ID, and identifiers and
+  # primary keys are _not_ always integers (can be UUID etc), we have expanded to allow
+  # any string value.
+  #
+  # However, for backwards compatibility #last always returns an integer (sometimes 0 if
+  # actual last component is not an integer), and #last_str returns the full string version.
+  # Trying to change #last itself to be string broke a lot of existing code in this gem
+  # in mysterious ways.
+  #
+  # Also beware that in some cases the value 0/"0" seems to be a special value used
+  # to signify some special case. A lot of "code archeology" going on here after significant
+  # period of no maintenance to this gem.
   class ResumptionToken
-    attr_reader :prefix, :set, :from, :until, :last, :expiration, :total
+    attr_reader :prefix, :set, :from, :until, :last, :last_str, :expiration, :total
 
     # parses a token string and returns a ResumptionToken
     def self.parse(token_string)
       begin
         options = {}
-        matches = /(.+):(\d+)$/.match(token_string)
-        options[:last] = matches.captures[1].to_i
-        
+        matches = /(.+):([^ :]+)$/.match(token_string)
+        options[:last] = matches.captures[1]
+
         parts = matches.captures[0].split('.')
         options[:metadata_prefix] = parts.shift
         parts.each do |part|
@@ -35,7 +60,7 @@ module OAI::Provider
         raise OAI::ResumptionTokenException.new
       end
     end
-    
+
     # extracts the metadata prefix from a token string
     def self.extract_format(token_string)
       return token_string.split('.')[0]
@@ -44,32 +69,34 @@ module OAI::Provider
     def initialize(options, expiration = nil, total = nil)
       @prefix = options[:metadata_prefix]
       @set = options[:set]
-      @last = options[:last]
+      @last = options[:last].to_i
+      @last_str = options[:last].to_s
       @from = options[:from] if options[:from]
       @until = options[:until] if options[:until]
       @expiration = expiration if expiration
       @total = total if total
     end
-          
+
     # convenience method for setting the offset of the next set of results
     def next(last)
-      @last = last
+      @last_str = last.to_s
+      @last = last.to_i
       self
     end
-    
+
     def ==(other)
       prefix == other.prefix and set == other.set and from == other.from and
-        self.until == other.until and last == other.last and 
+        self.until == other.until and last == other.last and
         expiration == other.expiration and total == other.total
     end
-    
+
     # output an xml resumption token
     def to_xml
       xml = Builder::XmlMarkup.new
       xml.resumptionToken(encode_conditions, hash_of_attributes)
       xml.target!
     end
-    
+
     # return a hash containing just the model selection parameters
     def to_conditions_hash
       conditions = {:metadata_prefix => self.prefix }
@@ -78,20 +105,24 @@ module OAI::Provider
       conditions[:until] = self.until if self.until
       conditions
     end
-    
-    # return the a string representation of the token minus the offset
+
+    # return the a string representation of the token minus the offset/ID
+    #
+    # Q: Why does it eliminate the offset/id "last" on the end? Doesn't fully
+    #    represent state without it, which is confusing. Not sure, but
+    #    other code seems to rely on it, tests break if not.
     def to_s
       encode_conditions.gsub(/:\w+?$/, '')
     end
 
     private
-    
+
     def encode_conditions
       encoded_token = @prefix.to_s.dup
       encoded_token << ".s(#{set})" if set
       encoded_token << ".f(#{self.from.utc.xmlschema})" if self.from
       encoded_token << ".u(#{self.until.utc.xmlschema})" if self.until
-      encoded_token << ":#{last}"
+      encoded_token << ":#{last_str}"
     end
 
     def hash_of_attributes

--- a/test/activerecord_provider/helpers/providers.rb
+++ b/test/activerecord_provider/helpers/providers.rb
@@ -35,6 +35,13 @@ class SimpleResumptionProvider < OAI::Provider::Base
   source_model ActiveRecordWrapper.new(DCField, :limit => 25)
 end
 
+class SimpleResumptionProviderWithNonIntegerID < OAI::Provider::Base
+  repository_name 'ActiveRecord Resumption Provider With Non-Integer ID'
+  repository_url 'http://localhost'
+  record_prefix 'oai:test'
+  source_model ActiveRecordWrapper.new(DCField, :limit => 25, identifier_field: "source")
+end
+
 class CachingResumptionProvider < OAI::Provider::Base
   repository_name 'ActiveRecord Caching Resumption Provider'
   repository_url 'http://localhost'

--- a/test/activerecord_provider/tc_simple_paging_provider.rb
+++ b/test/activerecord_provider/tc_simple_paging_provider.rb
@@ -8,17 +8,36 @@ class SimpleResumptionProviderTest < TransactionalTestCase
     assert_not_nil doc.elements["/OAI-PMH/ListRecords/resumptionToken"]
     assert_equal 26, doc.elements["/OAI-PMH/ListRecords"].to_a.size
     token = doc.elements["/OAI-PMH/ListRecords/resumptionToken"].text
+
     doc = Document.new(@provider.list_records(:resumption_token => token))
     assert_not_nil doc.elements["/OAI-PMH/ListRecords/resumptionToken"]
     token = doc.elements["/OAI-PMH/ListRecords/resumptionToken"].text
     assert_equal 26, doc.elements["/OAI-PMH/ListRecords"].to_a.size
+
     doc = Document.new(@provider.list_records(:resumption_token => token))
     assert_not_nil doc.elements["/OAI-PMH/ListRecords/resumptionToken"]
     token = doc.elements["/OAI-PMH/ListRecords/resumptionToken"].text
     assert_equal 26, doc.elements["/OAI-PMH/ListRecords"].to_a.size
+
     doc = Document.new(@provider.list_records(:resumption_token => token))
     assert_nil doc.elements["/OAI-PMH/ListRecords/resumptionToken"]
     assert_equal 25, doc.elements["/OAI-PMH/ListRecords"].to_a.size
+  end
+
+  def test_non_integer_identifiers_resumption
+    @provider = SimpleResumptionProviderWithNonIntegerID.new
+
+    doc = Document.new(@provider.list_records(:metadata_prefix => 'oai_dc'))
+    assert_not_nil doc.elements["/OAI-PMH/ListRecords/resumptionToken"]
+    assert_equal 26, doc.elements["/OAI-PMH/ListRecords"].to_a.size
+    token = doc.elements["/OAI-PMH/ListRecords/resumptionToken"].text
+
+    next_doc = Document.new(@provider.list_records(:resumption_token => token))
+    assert_not_nil next_doc.elements["/OAI-PMH/ListRecords/resumptionToken"]
+    next_token = next_doc.elements["/OAI-PMH/ListRecords/resumptionToken"].text
+    assert_equal 26, next_doc.elements["/OAI-PMH/ListRecords"].to_a.size
+
+    assert_not_equal token, next_token
   end
 
   def test_from_and_until

--- a/test/provider/tc_resumption_tokens.rb
+++ b/test/provider/tc_resumption_tokens.rb
@@ -43,4 +43,10 @@ class ResumptionTokenTest < Test::Unit::TestCase
     assert_equal "#{@token.to_s}:#{@token.last}", doc.elements['/resumptionToken'].text
   end
 
+  def test_resumption_token_id_does_not_need_to_be_numeric
+    serialized = "oai_dc.s(A).f(2005-01-01T17:00:00Z).u(2005-01-31T17:00:00Z):FA129C"
+
+    token = ResumptionToken.parse(serialized)
+    assert_equal serialized, token.send(:encode_conditions)
+  end
 end


### PR DESCRIPTION
…and with ActiveRecordWrapper resumption pagination

## Context

The OAI-PMH spec doesn't say anything about the structure of a `resumptionToken` it's just an opaque identifier to the client. 

This gem provides for a particular format of resumptionToken, where info is embedded in it to allow (in some cases) for stateless resumption/pagination. One component of this info, which happens to be the "last" item in the String, is something identifying the "last" record in the previous page, and is called by method/init arg `last` in the code. 

It could be a pagination numerical *offset* value -- the built-in ActiveRecordCachingWrapper provider uses it thusly. (I'm not sure if anyone actually uses this provider, or if it currently works). 

Or it could be an identifier/primary key -- the built-in `ActiveRecordWrapper` provider does it this way. (I'm not sure if anyone other than me is currently using this one). This relies on records being returned in sort-by-identifier/pk order, so the identifier/pk of the last record from the last page tells you where to start the next page. 

Dependent code not in this gem but using it might do either of those things with the `last` component in a ResumptionToken. The `blacklight_oai_provider` seems to currently use it as a numeric offset, but might be able to have a more efficient implementation using it as a solr uniqueKey identifier (solr is known not that efficient at deep-offset pagination, as are most rdbms). 

## Problem

The existing code before this PR assumed this last component is an _integer_.  The code for parsing it out of a serialized form assumed it was regexp `/d+`, and lots of other code just assumed it was an integer. 

This is not a valid assumption when it is an identifier/pk. Even if strictly a PK with the `ActiveRecordWrapper` -- these days, we have UUID pks. The feature added in #76 -- where even with ActiveRecordWrapper you might be using a non-pk unique column for identifier --  increases the space where this assumption can fail. (I ran into this in our local app, we thought we had oai-pmh working, but it turns out pagination was not working, which is why I returned to it). 

If `blacklight_oai_provider` wanted to use Solr UniqueKey's here instead of offsets -- it couldn't, as people's Solr UniqueKey's are not generally strictly integers. 

So we want to make the `last` component be supported as any string not just an integer. That's what's done here, sort of. 

## The solution

First I just tried changing it so it didn't assume `last` was an integer. But that broke *lots* of tests, especially around the ActiveRecordCachingWrapper (which I'm not sure if it truly works anyway or if anyone is using it, but anyway). 

And it was really hard to figure out what to change to get it working again, and it was lots of lines of changes -- this is very old, kind of creaky, not always well documented code, using ruby conventions from a decade ago (and the tests are also kind of hard to work with for me).  And there are undocumented conventions, like passing `0` (or now `"0"` as the `last` component seems to have a special meaning internally maybe meaning last page?)

So I took another stab at it, where the `#last`  is still an integer, but an additional `last_str` is available with a string form. And I fixed `ActiveRecordWrapper` so it pagination works again with non-numeric identifiers/pks. 

I left copious comments in the code, hopefully making it less mysterious for whoever comes next, because this code is a bit difficult, and I realize my appraoch here is sort of hacky. But I think it's the best for backwards compatibility (including with any dependent code that may assume #last is an integer), and for the purpose of changing as few lines as possible when we have code that we don't understand well, is difficult, and doesn't have a lot of hours for maintenance dedicated to it. 