### PR TITLE
Favoring instance over classes

### DIFF
--- a/test/provider/tc_instance_provider.rb
+++ b/test/provider/tc_instance_provider.rb
@@ -13,7 +13,7 @@ class TestInstanceProvider < Test::Unit::TestCase
   # response object.
   def test_instance_used_in_responses
     @url_path = "/stringy-mc-string-face"
-    @instance_provider = InstanceProvider.new(:instance_based, @url_path)
+    @instance_provider = InstanceProvider.new({ :provider_context => :instance_based, :url_path => @url_path })
 
     xml = @instance_provider.identify
     doc =  REXML::Document.new(xml)
@@ -22,7 +22,16 @@ class TestInstanceProvider < Test::Unit::TestCase
 
   def test_class_used_in_responses
     @url_path = "/stringy-mc-string-face"
-    @instance_provider = InstanceProvider.new(:class_based, @url_path)
+    @instance_provider = InstanceProvider.new({ :provider_context => :class_based, :url_path => @url_path })
+
+    xml = @instance_provider.identify
+    doc =  REXML::Document.new(xml)
+    assert_equal "http://localhost", doc.elements["OAI-PMH/Identify/baseURL"].text
+  end
+
+  def test_by_default_class_used_in_responses
+    @url_path = "/stringy-mc-string-face"
+    @instance_provider = InstanceProvider.new({ :url_path => @url_path })
 
     xml = @instance_provider.identify
     doc =  REXML::Document.new(xml)

--- a/test/provider/tc_instance_provider.rb
+++ b/test/provider/tc_instance_provider.rb
@@ -1,0 +1,32 @@
+require 'test_helper_provider'
+
+class TestInstanceProvider < Test::Unit::TestCase
+
+  # Prior to the commit introducing this code, the InstanceProvider#identify
+  # method would instantiate a Response::Identify object, passing the
+  # InstanceProvider class as the provider for the Response::Identify
+  # instance. With the commit introducing this test, the
+  # InstanceProvider#identify now passes the instance of InstanceProvider
+  # to the instantiation of Response::Identify.
+  #
+  # Thus we can override, on an instance by instance basis, the behavior of a
+  # response object.
+  def test_instance_used_in_responses
+    @url_path = "/stringy-mc-string-face"
+    @instance_provider = InstanceProvider.new(:instance_based, @url_path)
+
+    xml = @instance_provider.identify
+    doc =  REXML::Document.new(xml)
+    assert_equal "http://localhost#{@url_path}", doc.elements["OAI-PMH/Identify/baseURL"].text
+  end
+
+  def test_class_used_in_responses
+    @url_path = "/stringy-mc-string-face"
+    @instance_provider = InstanceProvider.new(:class_based, @url_path)
+
+    xml = @instance_provider.identify
+    doc =  REXML::Document.new(xml)
+    assert_equal "http://localhost", doc.elements["OAI-PMH/Identify/baseURL"].text
+  end
+
+end

--- a/test/provider/test_helper_provider.rb
+++ b/test/provider/test_helper_provider.rb
@@ -43,3 +43,20 @@ class DescribedProvider < Provider::Base
   sample_id '13900'
   extra_description "<my_custom_xml />"
 end
+
+class InstanceProvider < Provider::Base
+  repository_name 'Instance Provider'
+  record_prefix 'oai:test'
+  repository_url 'http://localhost'
+  source_model SimpleModel.new
+
+  def initialize(context_provider, url_path)
+    super(context_provider)
+    @url_path = url_path
+  end
+  attr_reader :url_path
+
+  def url
+    File.join(super, url_path)
+  end
+end

--- a/test/provider/test_helper_provider.rb
+++ b/test/provider/test_helper_provider.rb
@@ -50,9 +50,9 @@ class InstanceProvider < Provider::Base
   repository_url 'http://localhost'
   source_model SimpleModel.new
 
-  def initialize(context_provider, url_path)
-    super(context_provider)
-    @url_path = url_path
+  def initialize(options = {})
+    super
+    @url_path = options.fetch(:url_path)
   end
   attr_reader :url_path
 


### PR DESCRIPTION
## Allow switching on instance or class for provider

eae3c6c671288ce2f6e0aa9af00147493ae44c1f

Prior to this commit, instance methods of the Provider class were
passing the instance's class (e.g. Provider) to the associated response instances. This
was a surprise; Why would an instance method send as a parameter
it's class instead of the instance method's instance?

This made it difficult to add context to the Provider on a request by
request basis; In our implementation, we wanted to pass the controller
to the instantiated provider instance.

Further, the following line of code was dangerous, in that it would
override the URL for the entire class and all future uses. (Perhaps
that's the OAI specification, but it's a dangerous class mutation)

```ruby
self.class.url = params['url'] ? params.delete('url') : self.class.url
```

All told, this commit seeks to:

* preserve backwards compatibility by adding instance methods that
  mirror the expected class methods used by the Response module's
  classes.
* provide extensibility for downstream implementers when they
  instantiate an OAI::Provider

## Further refining Instance vs. Class provider opts

c99267120ee602a6ff615f6e23998525b60b0e4d

Based on feedback concerning the prior commit, this commit seeks to
further insulate the change of behavior to downstream implementors.

1) I added discussion and documentation about the change
2) I updated the tests accordingly
3) I added fall-back behavior in case someone inherited from
   OIA::Provider but did not initialize with `super`

The method documentation for `OAI::Provider::Base#provider_context`
highlights the entirity of this change:

> The traditional interaction of a Provider has been to:
>
> 1. Assign attributes to the Provider class
> 2. Instantiate the Provider class
> 3. Call response instance methods for theProvider which pass
>    the Provider class and not the instance.
>
> The above behavior continues unless you initialize the Provider with
> `{ :provider_context => :instance_based }`. If you do that, then the
>
> Provider behavior will be:
>
> 1. Assign attributes to Provider class
> 2. Instantiate the Provider class
> 3. Call response instance methods for theProvider which pass an
>    instance of the Provider to those response objects.
>    a. The instance will mirror all of the assigned Provider class
>       attributes, but allows for overriding and extending on a
>       case by case basis.
>
> (Dear reader, please note the second behavior is something most
> of us would've assumed to be the case, but for historic now lost
> reasons is not the case.)
