### PR TITLE
Allow Faraday 2.x

### DIFF
--- a/lib/oai/client.rb
+++ b/lib/oai/client.rb
@@ -331,7 +331,16 @@ module OAI
     # Regex is from WebCollab:
     #   http://webcollab.sourceforge.net/unicode.html
     def strip_invalid_utf_8_chars(xml)
-      xml && xml.gsub(/[\x00-\x08\x10\x0B\x0C\x0E-\x19\x7F]
+      return xml unless xml
+
+      # If it's in a specific encoding other than BINARY, it may trigger
+      # an exception to try to gsub these illegal bytes. Temporarily
+      # put it in BINARY. NOTE: We're not totally sure what's going on
+      # with encodings in this gem in general, it might not be totally reasonable.
+      orig_encoding = xml.encoding
+      xml.force_encoding("BINARY")
+
+      xml = xml.gsub(/[\x00-\x08\x10\x0B\x0C\x0E-\x19\x7F]
                              | [\x00-\x7F][\x80-\xBF]+
                              | ([\xC0\xC1]|[\xF0-\xFF])[\x80-\xBF]*
                              | [\xC2-\xDF]((?![\x80-\xBF])|[\x80-\xBF]{2,})
@@ -339,6 +348,10 @@ module OAI
                              | (?![\x80-\xBF]{2})|[\x80-\xBF]{3,})/x, '?')\
                 .gsub(/\xE0[\x80-\x9F][\x80-\xBF]
                        | \xED[\xA0-\xBF][\x80-\xBF]/,'?')
+
+      xml.force_encoding(orig_encoding)
+
+      xml
     end
 
   end

--- a/lib/oai/client.rb
+++ b/lib/oai/client.rb
@@ -331,7 +331,7 @@ module OAI
     # Regex is from WebCollab:
     #   http://webcollab.sourceforge.net/unicode.html
     def strip_invalid_utf_8_chars(xml)
-      return xml unless xml
+      return nil unless xml
 
       # If it's in a specific encoding other than BINARY, it may trigger
       # an exception to try to gsub these illegal bytes. Temporarily

--- a/lib/oai/client.rb
+++ b/lib/oai/client.rb
@@ -95,7 +95,8 @@ module OAI
           follow_redirects = 5 if follow_redirects == true
 
           if follow_redirects
-            require 'faraday_middleware'
+            require 'faraday/follow_redirects'
+            builder.use Faraday::FollowRedirects::Middleware
             builder.response :follow_redirects, :limit => follow_redirects.to_i
           end
           builder.adapter :net_http

--- a/ruby-oai.gemspec
+++ b/ruby-oai.gemspec
@@ -12,8 +12,10 @@ Gem::Specification.new do |s|
     s.executables = 'oai'
 
     s.add_dependency('builder', '>=3.1.0')
-    s.add_dependency('faraday')
-    s.add_dependency('faraday_middleware')
+    s.add_dependency('faraday', "< 3")
+    #s.add_dependency('faraday_middleware')
+    s.add_dependency("faraday-follow_redirects", ">= 0.3.0", "< 2")
+
 
     s.add_development_dependency "activerecord", ">= 5.2.0", "< 6.1"
     s.add_development_dependency "appraisal"

--- a/test/client/tc_http_client.rb
+++ b/test/client/tc_http_client.rb
@@ -58,8 +58,8 @@ eos
     end
 
     faraday_stub = Faraday.new do |builder|
-      require 'faraday_middleware'
-      builder.use FaradayMiddleware::FollowRedirects
+      require 'faraday/follow_redirects'
+      builder.use Faraday::FollowRedirects::Middleware
       builder.adapter :test, stubs
     end
 


### PR DESCRIPTION
Closes #89

## Allow Faraday 2.x, by switching from faraday-middleware to the new faraday_follow-redirects gem

By switching from faraday-middleware to the new faraday_follow-redirects gem

The new gem is compatible with both faraday 1 and 2, while faraday-middleware (which included a redirect middleware) has a gemspec that does not allow faraday 2.

I manually tested on faraday 1 by editing Gemfile locally -- it passes. I'm not sure if we want to regularly/automated test on both faraday 1 and 2?  Right now we have no automated CI at all, see #87

## Strip invalid chars without raising encoding exception regardless of encoding

On upgrade to faraday 2, HTTP responses can come back in specific encodings per the content-type of response. This effected one of our tests, that is using a live query to google.com (probably not a great idea), that comes back ISO-8859-1. But it actually would have failed if UTF-8 too, because we're trying to gsub some intentionally illegal bytes.   I am not sure if the approach to encoding is totally sound in this gem in general -- XML does have to be Unicode legally, but can be UTF-8 or -16, this strip routine may be assuming UTF8? But not actually properly making it with the ruby UTF8 encoding?

But this is just an attempt to change as little as possible leaving as backward compat as possible while passing tests in faraday 2; and resolving the specific problem of the strip_invalid_utf_8_chars failing when response comes back with ruby encoding tag from faraday 2.
