### PR TITLE
Resumption token incomplete list

### DIFF
--- a/lib/oai/provider/model.rb
+++ b/lib/oai/provider/model.rb
@@ -29,7 +29,7 @@ module OAI::Provider
   # see the ResumptionToken class for more details.
   #
   class Model
-    attr_reader :timestamp_field, :identifier_field
+    attr_reader :timestamp_field, :identifier_field, :limit
 
     def initialize(limit = nil, timestamp_field = 'updated_at', identifier_field = 'id')
       @limit = limit

--- a/lib/oai/provider/model/activerecord_caching_wrapper.rb
+++ b/lib/oai/provider/model/activerecord_caching_wrapper.rb
@@ -78,13 +78,7 @@ module OAI::Provider
       raise ResumptionTokenException.new unless @limit
 
       token = ResumptionToken.parse(token_string)
-      total = model.where(token_conditions(token)).count
-
-      if token.last * @limit + @limit < total
-        select_partial(token)
-      else
-        select_partial(token).tap { |list| list.instance_variable_set(:@token, list.token.next(nil)) }
-      end
+      select_partial(token)
     end
 
     # select a subset of the result set, and return it with a
@@ -102,10 +96,13 @@ module OAI::Provider
 
       raise ResumptionTokenException.new unless oaitoken
 
+      total = model.where(token_conditions(token)).count
+      # token offset should be nil if this is the last set
+      offset = (token.last * @limit + @limit >= total) ? nil : token.last + 1
       PartialResult.new(
         hydrate_records(
           oaitoken.entries.limit(@limit).offset(token.last * @limit)),
-        token.next(token.last + 1)
+        token.next(offset)
       )
     end
 

--- a/lib/oai/provider/model/activerecord_caching_wrapper.rb
+++ b/lib/oai/provider/model/activerecord_caching_wrapper.rb
@@ -83,7 +83,7 @@ module OAI::Provider
       if token.last * @limit + @limit < total
         select_partial(token)
       else
-        select_partial(token).records
+        select_partial(token).tap { |list| list.instance_variable_set(:@token, list.token.next(nil)) }
       end
     end
 

--- a/lib/oai/provider/model/activerecord_wrapper.rb
+++ b/lib/oai/provider/model/activerecord_wrapper.rb
@@ -134,9 +134,7 @@ module OAI::Provider
       if @limit < total
         select_partial(find_scope, token)
       else # end of result set
-        find_scope.where(token_conditions(token))
-          .limit(@limit)
-          .order("#{identifier_field} asc")
+        select_partial(find_scope, token).tap { |list| list.instance_variable_set(:@token, list.token.next(nil)) }
       end
     end
 

--- a/lib/oai/provider/resumption_token.rb
+++ b/lib/oai/provider/resumption_token.rb
@@ -122,6 +122,8 @@ module OAI::Provider
     end
 
     def encode_conditions
+      return "" if last_str.blank?
+
       encoded_token = @prefix.to_s.dup
       encoded_token << ".s(#{set})" if set
       encoded_token << ".f(#{self.from.utc.xmlschema})" if self.from

--- a/lib/oai/provider/resumption_token.rb
+++ b/lib/oai/provider/resumption_token.rb
@@ -122,7 +122,7 @@ module OAI::Provider
     end
 
     def encode_conditions
-      return "" if last_str.blank?
+      return "" if last_str.nil? || last_str.to_s.strip.eql?("")
 
       encoded_token = @prefix.to_s.dup
       encoded_token << ".s(#{set})" if set

--- a/lib/oai/provider/resumption_token.rb
+++ b/lib/oai/provider/resumption_token.rb
@@ -36,7 +36,7 @@ module OAI::Provider
     attr_reader :prefix, :set, :from, :until, :last, :last_str, :expiration, :total
 
     # parses a token string and returns a ResumptionToken
-    def self.parse(token_string)
+    def self.parse(token_string, expiration = nil, total = nil)
       begin
         options = {}
         matches = /(.+):([^ :]+)$/.match(token_string)
@@ -54,7 +54,7 @@ module OAI::Provider
             options[:until] = Time.parse(part.sub(/^u\(/, '').sub(/\)$/, '')).localtime
           end
         end
-        self.new(options)
+        self.new(options, expiration, total)
       rescue => err
         raise OAI::ResumptionTokenException.new
       end

--- a/test/activerecord_provider/tc_caching_paging_provider.rb
+++ b/test/activerecord_provider/tc_caching_paging_provider.rb
@@ -17,8 +17,9 @@ class CachingPagingProviderTest < TransactionalTestCase
     token = doc.elements["/OAI-PMH/ListRecords/resumptionToken"].text
     assert_equal 26, doc.elements["/OAI-PMH/ListRecords"].size
     doc = Document.new(@provider.list_records(:resumption_token => token))
-    assert_nil doc.elements["/OAI-PMH/ListRecords/resumptionToken"]
-    assert_equal 25, doc.elements["/OAI-PMH/ListRecords"].size
+    assert_not_nil doc.elements["/OAI-PMH/ListRecords/resumptionToken"]
+    assert_nil doc.elements["/OAI-PMH/ListRecords/resumptionToken"].text
+    assert_equal 26, doc.elements["/OAI-PMH/ListRecords"].to_a.size
   end
 
   def test_from_and_until
@@ -37,8 +38,9 @@ class CachingPagingProviderTest < TransactionalTestCase
     token = doc.elements["/OAI-PMH/ListRecords/resumptionToken"].text
     assert_not_nil doc.elements["/OAI-PMH/ListRecords/resumptionToken"]
     doc = Document.new(@provider.list_records(:resumption_token => token))
-    assert_equal 25, doc.elements["/OAI-PMH/ListRecords"].size
-    assert_nil doc.elements["/OAI-PMH/ListRecords/resumptionToken"]
+    assert_not_nil doc.elements["/OAI-PMH/ListRecords/resumptionToken"]
+    assert_nil doc.elements["/OAI-PMH/ListRecords/resumptionToken"].text
+    assert_equal 26, doc.elements["/OAI-PMH/ListRecords"].to_a.size
   end
 
   def setup

--- a/test/activerecord_provider/tc_simple_paging_provider.rb
+++ b/test/activerecord_provider/tc_simple_paging_provider.rb
@@ -20,8 +20,9 @@ class SimpleResumptionProviderTest < TransactionalTestCase
     assert_equal 26, doc.elements["/OAI-PMH/ListRecords"].to_a.size
 
     doc = Document.new(@provider.list_records(:resumption_token => token))
-    assert_nil doc.elements["/OAI-PMH/ListRecords/resumptionToken"]
-    assert_equal 25, doc.elements["/OAI-PMH/ListRecords"].to_a.size
+    assert_not_nil doc.elements["/OAI-PMH/ListRecords/resumptionToken"]
+    assert_nil doc.elements["/OAI-PMH/ListRecords/resumptionToken"].text
+    assert_equal 26, doc.elements["/OAI-PMH/ListRecords"].to_a.size
   end
 
   def test_non_integer_identifiers_resumption
@@ -58,8 +59,9 @@ class SimpleResumptionProviderTest < TransactionalTestCase
     assert_not_nil doc.elements["/OAI-PMH/ListRecords/resumptionToken"]
     token = doc.elements["/OAI-PMH/ListRecords/resumptionToken"].text
     doc = Document.new(@provider.list_records(:resumption_token => token))
-    assert_equal 25, doc.elements["/OAI-PMH/ListRecords"].to_a.size
-    assert_nil doc.elements["/OAI-PMH/ListRecords/resumptionToken"]
+    assert_not_nil doc.elements["/OAI-PMH/ListRecords/resumptionToken"]
+    assert_nil doc.elements["/OAI-PMH/ListRecords/resumptionToken"].text
+    assert_equal 26, doc.elements["/OAI-PMH/ListRecords"].to_a.size
   end
 
   def setup

--- a/test/provider/models.rb
+++ b/test/provider/models.rb
@@ -68,7 +68,7 @@ class TestModel < OAI::Provider::Model
           if token.last < @groups.size - 1
             PartialResult.new(@groups[token.last], token.next(token.last + 1))
           else
-            @groups[token.last]
+            PartialResult.new(@groups[token.last], token.next(nil))
           end
         rescue
           raise OAI::ResumptionTokenException.new

--- a/test/provider/tc_functional_tokens.rb
+++ b/test/provider/tc_functional_tokens.rb
@@ -46,9 +46,10 @@ class ResumptionTokenFunctionalTest < Test::Unit::TestCase
     token = doc.elements["/OAI-PMH/ListRecords/resumptionToken"].text
 
     doc = Document.new(@provider.list_records(:resumption_token => token))
-    assert_nil doc.elements["/OAI-PMH/ListRecords/resumptionToken"]
-    assert_equal (300 % @provider.model.limit), doc.elements["/OAI-PMH/ListRecords"].to_a.size
-    token = doc.elements["/OAI-PMH/ListRecords/resumptionToken"].text
+    # assert that ListRecords includes remaining records and an empty resumption token
+    assert_equal (301 % @provider.model.limit), doc.elements["/OAI-PMH/ListRecords"].to_a.size
+    assert_not_nil doc.elements["/OAI-PMH/ListRecords/resumptionToken"]
+    assert_nil doc.elements["/OAI-PMH/ListRecords/resumptionToken"].text
   end
 
 end


### PR DESCRIPTION
This is a rebased and tested version of the changes in #54 
The OAI spec for [Flow Control](http://www.openarchives.org/OAI/openarchivesprotocol.html#FlowControl):

> the response containing the incomplete list that completes the list must include an empty resumptionToken element;

Previously ruby-oai returned a nil resumption token in these scenarios. This PR changes the serialization of ResumptionToken when the `last` reference is blank (per @gcolson), and exercises the bundle providers for the change to include an empty token element rather than nil.