### PR TITLE
Provider helper methods should be able to provide value and attributes

### DIFF
--- a/lib/oai/provider/metadata_format.rb
+++ b/lib/oai/provider/metadata_format.rb
@@ -34,7 +34,7 @@ module OAI::Provider::Metadata
               values = value_for(field, record, map)
               if values.respond_to?(:each)
                 values.each do |value|
-                  xml.tag! "#{element_namespace}:#{field}", value
+                  xml.tag! "#{element_namespace}:#{field}", *value
                 end
               else
                 xml.tag! "#{element_namespace}:#{field}", values


### PR DESCRIPTION
For instance:
  def relation
    [ 'value without atribute', [ 'french value', { 'xml:lang' => 'fre' } ] ]
  end
gives
<dc:relation>value without atribute</dc:relation><dc:relation xml:lang=fre>french value</dc:relation>

Extracted from #47 