### PR TITLE
use named exceptions in OAI::Response

### DIFF
--- a/lib/oai/client/response.rb
+++ b/lib/oai/client/response.rb
@@ -46,7 +46,7 @@ module OAI
            end
          end
       end
-      raise OAI::Exception.new(message, code)
+      raise OAI::Exception.for(message: message, code: code)
     end
 
   end

--- a/lib/oai/exception.rb
+++ b/lib/oai/exception.rb
@@ -4,72 +4,80 @@ module OAI
   # messages will be wrapped in an XML response to the client.
 
   class Exception < RuntimeError
+    CODE = nil
+    MESSAGE = nil
+
     attr_reader :code
 
-    def initialize(message, code = nil)
-      super(message)
-      @code = code
+    @@codes = {}
+
+    def self.register_exception_code(code, exception_class)
+      @@codes[code] = exception_class if exception_class.superclass == OAI::Exception
+    end
+
+    def self.for(message: nil, code: nil)
+      @@codes.fetch(code, Exception).new(message)
+    end
+
+    def initialize(message = nil, code = nil)
+      super(message || self.class::MESSAGE)
+      @code = code || self.class::CODE
     end
   end
 
   class ArgumentException < Exception
-    def initialize()
-      super('The request includes ' \
+    CODE = 'badArgument'
+    MESSAGE = 'The request includes ' \
       'illegal arguments, is missing required arguments, includes a ' \
-      'repeated argument, or values for arguments have an illegal syntax.',
-      'badArgument')
-    end
+      'repeated argument, or values for arguments have an illegal syntax.'
+    register_exception_code(CODE, self)
   end
 
   class VerbException < Exception
-    def initialize()
-      super('Value of the verb argument is not a legal OAI-PMH '\
-      'verb, the verb argument is missing, or the verb argument is repeated.',
-      'badVerb')
-    end
+    CODE = 'badVerb'
+    MESSAGE = 'Value of the verb argument is not a legal OAI-PMH '\
+      'verb, the verb argument is missing, or the verb argument is repeated.'
+    register_exception_code(CODE, self)
   end
 
   class FormatException < Exception
-    def initialize()
-      super('The metadata format identified by '\
+    CODE = 'cannotDisseminateFormat'
+    MESSAGE = 'The metadata format identified by '\
         'the value given for the metadataPrefix argument is not supported '\
-        'by the item or by the repository.', 'cannotDisseminateFormat')
-    end
+        'by the item or by the repository.'
+    register_exception_code(CODE, self)
   end
 
   class IdException < Exception
-    def initialize()
-      super('The value of the identifier argument is '\
-        'unknown or illegal in this repository.', 'idDoesNotExist')
-    end
+    CODE = 'idDoesNotExist'
+    MESSAGE = 'The value of the identifier argument is '\
+        'unknown or illegal in this repository.'
+    register_exception_code(CODE, self)
   end
 
   class NoMatchException < Exception
-    def initialize()
-      super('The combination of the values of the from, '\
-      'until, set and metadataPrefix arguments results in an empty list.',
-      'noRecordsMatch')
-    end
+    CODE = 'noRecordsMatch'
+    MESSAGE = 'The combination of the values of the from, '\
+      'until, set and metadataPrefix arguments results in an empty list.'
+    register_exception_code(CODE, self)
   end
 
   class MetadataFormatException < Exception
-    def initialize()
-      super('There are no metadata formats available '\
-        'for the specified item.', 'noMetadataFormats')
-    end
+    CODE = 'noMetadataFormats'
+    MESSAGE = 'There are no metadata formats available '\
+        'for the specified item.'
+    register_exception_code(CODE, self)
   end
 
   class SetException < Exception
-    def initialize()
-      super('This repository does not support sets.', 'noSetHierarchy')
-    end
+    CODE = 'noSetHierarchy'
+    MESSAGE = 'This repository does not support sets.'
+    register_exception_code(CODE, self)
   end
 
   class ResumptionTokenException < Exception
-    def initialize()
-      super('The value of the resumptionToken argument is invalid or expired.',
-        'badResumptionToken')
-    end
+    CODE = 'badResumptionToken'
+    MESSAGE = 'The value of the resumptionToken argument is invalid or expired.'
+    register_exception_code(CODE, self)
   end
-
 end

--- a/test/client/tc_exception.rb
+++ b/test/client/tc_exception.rb
@@ -18,7 +18,7 @@ class ExceptionTest < Test::Unit::TestCase
 
   def test_oai_error
     client = OAI::Client.new 'http://localhost:3333/oai'
-    assert_raises(OAI::Exception) do
+    assert_raises(OAI::ResumptionTokenException) do
       client.list_identifiers :resumption_token => 'bogus'
     end
   end

--- a/test/client/tc_get_record.rb
+++ b/test/client/tc_get_record.rb
@@ -25,7 +25,7 @@ class GetRecordTest < Test::Unit::TestCase
     begin
       client.get_record :metadata_prefix => 'oai_dc'
       flunk 'invalid get_record did not throw OAI::Exception'
-    rescue OAI::Exception => e
+    rescue OAI::ArgumentException => e
       assert_match /The request includes illegal arguments/, e.to_s
     end
   end

--- a/test/client/tc_libxml.rb
+++ b/test/client/tc_libxml.rb
@@ -7,7 +7,7 @@ class LibXMLTest < Test::Unit::TestCase
 
     uri = 'http://localhost:3333/oai'
     client = OAI::Client.new uri, :parser => 'libxml'
-    assert_raises(OAI::Exception) {client.get_record(:identifier => 'nosuchid')}
+    assert_raises(OAI::IdException) {client.get_record(:identifier => 'nosuchid')}
   end
 
   def test_list_records


### PR DESCRIPTION
OAI::Exception subclasses are registered by code so that OAI::Response can raise named exceptions

- update tests to expect named exception subclasses
- fixes #50