### PR TITLE
Requiring metadata_prefix for ListIdentifiers, per OAI-PMH specs

### DIFF
--- a/lib/oai/provider/response/list_identifiers.rb
+++ b/lib/oai/provider/response/list_identifiers.rb
@@ -1,7 +1,8 @@
 module OAI::Provider::Response
   
   class ListIdentifiers < RecordResponse
-    
+    required_parameters :metadata_prefix
+
     def to_xml
       result = provider.model.find(:all, options)
 

--- a/test/activerecord_provider/tc_ar_provider.rb
+++ b/test/activerecord_provider/tc_ar_provider.rb
@@ -53,8 +53,10 @@ class ActiveRecordProviderTest < TransactionalTestCase
   end
 
   def test_list_identifiers
-    assert_nothing_raised { REXML::Document.new(@provider.list_identifiers) }
-    doc = REXML::Document.new(@provider.list_identifiers)
+    assert_nothing_raised do
+      REXML::Document.new(@provider.list_identifiers(:metadata_prefix => 'oai_dc'))
+    end
+    doc = REXML::Document.new(@provider.list_identifiers(:metadata_prefix => 'oai_dc'))
     assert_equal 100, doc.elements['OAI-PMH/ListIdentifiers'].to_a.size
   end
 
@@ -163,7 +165,7 @@ class ActiveRecordProviderTest < TransactionalTestCase
     test_metadata_formats
     # ListIdentifiers and ListRecords should return "noRecordsMatch" error code
     assert_raises(OAI::NoMatchException) do
-      REXML::Document.new(@provider.list_identifiers)
+      REXML::Document.new(@provider.list_identifiers(:metadata_prefix => 'oai_dc'))
     end
     assert_raises(OAI::NoMatchException) do
       REXML::Document.new(@provider.list_records(:metadata_prefix => 'oai_dc'))

--- a/test/provider/tc_provider.rb
+++ b/test/provider/tc_provider.rb
@@ -15,7 +15,8 @@ class OaiTest < Test::Unit::TestCase
   end
 
   def test_list_identifiers_for_correct_xml
-    doc = REXML::Document.new(@mapped_provider.list_identifiers)
+    doc = REXML::Document.new(
+      @mapped_provider.list_identifiers(:metadata_prefix => 'oai_dc'))
     assert_not_nil doc.elements['OAI-PMH/request']
     assert_not_nil doc.elements['OAI-PMH/request/@verb']
     assert_not_nil doc.elements['OAI-PMH/ListIdentifiers']


### PR DESCRIPTION
Per the OAI-PMH specs, `metadataPrefix` is a _**required**_ parameter for ListIdentifiers.  As such, the code for ListIdentifiers should not just assume a default if it is not supplied.
In our use case, the values returned by a ListIdentifier call depend on the prefix because some identifiers are only valid for requesting data in certain formats.