### PR TITLE
If AR model provides no "sets", then default should be [] instead of nil to avoid uncaught exception

### DIFF
--- a/lib/oai/provider/model/activerecord_wrapper.rb
+++ b/lib/oai/provider/model/activerecord_wrapper.rb
@@ -44,7 +44,7 @@ module OAI::Provider
     # returns all the sets the model supports.  See the
     # activerecord_provider tests for an example.
     def sets
-      model.sets if model.respond_to?(:sets)
+      model.respond_to?(:sets) ? model.sets : []
     end
 
     def find(selector, options={})
@@ -177,7 +177,7 @@ module OAI::Provider
         sql << "#{model.base_class.table_name}.#{timestamp_field} < :until"
         esc_values[:until] = parse_to_local(opts[:until]) { |t| t + 1 }
       end
-      
+
       return [sql.join(" AND "), esc_values]
     end
 
@@ -197,7 +197,7 @@ module OAI::Provider
           raise OAI::ArgumentException.new, "unparsable date: '#{time}'"
         end
       end
-        
+
       time_obj = yield(time_obj) if block_given?
 
       if time_obj.kind_of?(Date)

--- a/test/activerecord_provider/tc_ar_provider.rb
+++ b/test/activerecord_provider/tc_ar_provider.rb
@@ -40,6 +40,11 @@ class ActiveRecordProviderTest < TransactionalTestCase
     assert_equal expected_count, doc.elements['OAI-PMH/ListRecords'].to_a.size
   end
 
+  def test_invalid_set_raises_no_match
+    assert_raises(OAI::NoMatchException) do
+      @provider.list_records(:metadata_prefix => 'oai_dc', :set => "invalid_does_not_exist")
+    end
+  end
 
   def test_get_record_alternate_identifier_column
     @provider = ARProviderCustomIdentifierField.new
@@ -127,7 +132,7 @@ class ActiveRecordProviderTest < TransactionalTestCase
       )
     assert_equal 40, doc.elements['OAI-PMH/ListRecords'].to_a.size
   end
-  
+
   def test_bad_until_raises_exception
     DCField.order(id: :asc).limit(10).update_all(updated_at: 1.year.ago)
     DCField.order(id: :desc).limit(10).update_all(updated_at: 1.year.from_now)
@@ -140,11 +145,11 @@ class ActiveRecordProviderTest < TransactionalTestCase
       end
     end
   end
-  
+
   def test_bad_from_raises_exception
     DCField.order(id: :asc).limit(10).update_all(updated_at: 1.year.ago)
     DCField.order(id: :desc).limit(10).update_all(updated_at: 1.year.from_now)
-    
+
     badTimes = [
       'junk',
       'February 92nd, 2015']
@@ -169,7 +174,7 @@ class ActiveRecordProviderTest < TransactionalTestCase
       REXML::Document.new(@provider.list_records(:metadata_prefix => 'oai_dc'))
     end
   end
-  
+
   def test_bad_id_raises_exception
     badIdentifiers = [
       'invalid"id',
@@ -183,7 +188,7 @@ class ActiveRecordProviderTest < TransactionalTestCase
       end
     end
   end
-  
+
 
   def setup
     @provider = ARProvider.new


### PR DESCRIPTION
Previously, if the model defined no sets, and a client asked for them, an uncaught exception would be raised, `NoMethodError: undefined method `detect' for nil`

With a pretty darn confusing stack trace
```
/Users/jrochkind/code/ruby-oai/lib/oai/provider/model/activerecord_wrapper.rb:123:in `find_set_by_spec'
/Users/jrochkind/code/ruby-oai/lib/oai/provider/model/activerecord_wrapper.rb:99:in `find_scope'
/Users/jrochkind/code/ruby-oai/lib/oai/provider/model/activerecord_wrapper.rb:51:in `find'
/Users/jrochkind/code/ruby-oai/lib/oai/provider/response/list_records.rb:19:in `to_xml'
/Users/jrochkind/code/ruby-oai/lib/oai/provider.rb:444:in `list_records'
/Users/jrochkind/code/ruby-oai/lib/oai/provider.rb:470:in `process_request'
app/controllers/oai_pmh_controller.rb:27:in `index'
```

By making the default return `[]` instead of `nil`, it changes to an appropriate `OAI::NoMatchException` which is rescued properly by controller to return this response:

```xml
<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
<responseDate>2025-03-04T17:56:12Z</responseDate>
<request>http://localhost:3000/oai</request>
<error code="noRecordsMatch">The combination of the values of the from, until, set and metadataPrefix arguments results in an empty list.</error>
</OAI-PMH>
```

I don't know if it's ideal, but seems to be what was intended. 

I do not use sets, and am not totally sure functionality is working if you do, haven't tracked down a test and the code isn't looking great to me -- But pretty sure this change won't break anything, a `sets` method that was defined, as modelled, seems like `[]` would be a legal return value. But maybe not `nil`. 

Got to the bottom of this after local error: https://github.com/sciencehistory/scihist_digicoll/issues/2911
